### PR TITLE
Potential fix for code scanning alert no. 7: Multiplication result converted to larger type

### DIFF
--- a/Application/src/grabber/gif.h
+++ b/Application/src/grabber/gif.h
@@ -351,7 +351,7 @@ void GifMakePalette( const uint8_t* lastFrame, const uint8_t* nextFrame, uint32_
     
     // SplitPalette is destructive (it sorts the pixels by color) so
     // we must create a copy of the image for it to destroy
-    int imageSize = width*height*4*sizeof(uint8_t);
+    size_t imageSize = static_cast<size_t>(width) * static_cast<size_t>(height) * 4u * sizeof(uint8_t);
     uint8_t* destroyableImage = (uint8_t*)GIF_TEMP_MALLOC(imageSize);
     memcpy(destroyableImage, nextFrame, imageSize);
     


### PR DESCRIPTION
Potential fix for [https://github.com/mooch443/trex/security/code-scanning/7](https://github.com/mooch443/trex/security/code-scanning/7)

Compute image byte size using `size_t` and cast operands *before* multiplication so the arithmetic is performed in the larger type. Then pass that `size_t` to allocation and copy.

Best fix in this snippet:
- In `Application/src/grabber/gif.h`, inside `GifMakePalette(...)`, replace:
  - `int imageSize = width*height*4*sizeof(uint8_t);`
with
  - `size_t imageSize = static_cast<size_t>(width) * static_cast<size_t>(height) * 4u * sizeof(uint8_t);`
- Keep `GIF_TEMP_MALLOC(imageSize)` and `memcpy(..., imageSize)` using this `size_t` value.
- No new imports are needed (`size_t` is already available via existing C headers in this file context).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential memory overflow vulnerability in GIF image processing that could cause application crashes or unexpected behavior, enhancing overall stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mooch443/trex/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->