### PR TITLE
Keep boundary menu clamp in bowl coordinates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,63 @@
+# TRex Repository Instructions
+
+TRex is a C++ application with a standalone `commons` library for shared
+utilities and GUI infrastructure. Keep changes scoped to the task and follow
+the existing local patterns before introducing new abstractions.
+
+## Repository Layout
+
+- `Application/` is the main CMake project.
+- `Application/src/commons/` is the shared commons library.
+- `Application/src/tracker/` is the TRex GUI application.
+- `Application/src/ProcessedVideo/` handles PV format code.
+- `Application/Tests/` contains gtest/gmock unit tests.
+- `docs/` contains Sphinx documentation.
+- `Application/src/grabber/` is deprecated; do not use it as a reference for
+  new GUI structure or best practices.
+
+## C++ Conventions
+
+- Prefer existing project helpers, types, and ownership patterns.
+- Most source files include the precompiled header `commons.pc.h`; when adding
+  a new implementation file, put `#include <commons.pc.h>` before other
+  includes unless a nearby file shows a different established pattern.
+- Keep edits minimal and avoid unrelated refactors, formatting churn, or broad
+  metadata changes.
+- Add comments only when they clarify non-obvious behavior.
+- Use structured parsing or existing helper APIs rather than ad hoc string
+  manipulation when the codebase already provides a suitable option.
+
+## GUI Guidance
+
+- Prefer the scene system for main TRex UI flows. Implement `gui::Scene`
+  objects that own state, draw UI, and respond to global events.
+- Use DynamicGUI for complex JSON-driven layouts and rapid iteration. Define
+  variables with `dyn::VarFunc`, actions with `dyn::ActionFunc`, and load
+  layouts via `file::DataLocation::parse(...)`.
+- Keep GUI work on the main thread. Use `SceneManager::getInstance().gui_task_queue()`
+  or the scene task queue for deferred work and long-running side effects.
+- Be careful with coordinate spaces. TRex UI commonly converts between
+  `HUDCoord`, `BowlCoord`, `HUDRect`, and `BowlRect` through `FindCoord`.
+  Convert sizes, offsets, and hit-test bounds into the same coordinate space
+  before comparing or clamping them.
+- Reserve direct draw calls for small custom widgets and localized overlays.
+
+## Tests And Validation
+
+- When fixing a bug, first reproduce the failure with a minimal viable test or
+  local repro when practical, then fix the code until that repro passes.
+- Add targeted regression tests only when they materially validate the reported
+  issue. Avoid broad or speculative tests.
+- If modifying tests, keep changes limited to tests and the smallest necessary
+  test wiring such as `Application/Tests/CMakeLists.txt`.
+- Do not run commands in existing build directories or delete project files in
+  build directories.
+
+## Build Notes
+
+- Use the repository CMake project under `Application/` for normal builds.
+- For conda builds, prefer the recipe in `conda/`; GitHub Actions uses the same
+  conda build flow.
+- Use only the `trex` or `trex-modules` conda environments for
+  environment-specific commands. For Python in the `trex` environment, prefer
+  `KMP_DUPLICATE_LIB_OK=TRUE conda run -n trex python ...` on macOS.

--- a/Application/src/tracker/ui/DrawBlobView.cpp
+++ b/Application/src/tracker/ui/DrawBlobView.cpp
@@ -1544,13 +1544,15 @@ void BlobView::draw_boundary_selection(DrawStructure& base, Base* window, GUICac
                 auto coords = FindCoord::get();
                 auto viewport = coords.viewport();
                 
-                auto object_bounds = Bounds{p, combine->size()};
+                const auto object_size = combine->size().mul(sca);
+                const auto viewport_padding = Vec2(100, 80).mul(sca);
+                auto object_bounds = Bounds{p, object_size};
                 
-                if(object_bounds.x - viewport.x < 100) {
-                    object_bounds.x = viewport.x + 100;
+                if(object_bounds.x - viewport.x < viewport_padding.x) {
+                    object_bounds.x = viewport.x + viewport_padding.x;
                 }
-                if(object_bounds.y - viewport.y < 80) {
-                    object_bounds.y = viewport.y + 80;
+                if(object_bounds.y - viewport.y < viewport_padding.y) {
+                    object_bounds.y = viewport.y + viewport_padding.y;
                 }
                 if(object_bounds.x - viewport.x >= viewport.width) {
                     object_bounds.x = viewport.x + viewport.width - object_bounds.width;
@@ -1612,4 +1614,3 @@ void BlobView::draw_boundary_selection(DrawStructure& base, Base* window, GUICac
 }
 
 }
-

--- a/Application/src/tracker/ui/DrawBlobView.cpp
+++ b/Application/src/tracker/ui/DrawBlobView.cpp
@@ -1,3 +1,5 @@
+#include <commons.pc.h>
+
 #include "DrawBlobView.h"
 #include <gui/DrawStructure.h>
 #include <ui/GUICache.h>
@@ -1546,7 +1548,20 @@ void BlobView::draw_boundary_selection(DrawStructure& base, Base* window, GUICac
                 
                 const auto object_size = combine->size().mul(sca);
                 const auto viewport_padding = Vec2(100, 80).mul(sca);
-                auto object_bounds = Bounds{p, object_size};
+                auto update_origin = [&]() {
+                    auto screen_pos = coords.convert(BowlCoord{p});
+                    float top = screen_pos.y < coords.screen_size().height * 0.5
+                                ? 0.f : 1.f;
+                    if(screen_pos.x < coords.screen_size().width * 0.5) {
+                        combine->set_origin(Vec2(0, top));
+                    } else {
+                        combine->set_origin(Vec2(1, top));
+                    }
+                };
+                update_origin();
+
+                auto object_top_left = p - object_size.mul(combine->origin());
+                auto object_bounds = Bounds{object_top_left, object_size};
                 
                 if(object_bounds.x - viewport.x < viewport_padding.x) {
                     object_bounds.x = viewport.x + viewport_padding.x;
@@ -1561,18 +1576,7 @@ void BlobView::draw_boundary_selection(DrawStructure& base, Base* window, GUICac
                     object_bounds.y = viewport.y + viewport.height - object_bounds.height;
                 }
                 
-                p = object_bounds.pos();
-                
-                /// check which direction we should be looking wrt
-                /// screen viewport and object size:
-                auto screen_pos = coords.convert(BowlCoord{p});
-                float top = screen_pos.y < coords.screen_size().height * 0.5
-                            ? 0.f : 1.f;
-                if(screen_pos.x < coords.screen_size().width * 0.5) {
-                    combine->set_origin(Vec2(0, top));
-                } else {
-                    combine->set_origin(Vec2(1, top));
-                }
+                p = object_bounds.pos() + object_size.mul(combine->origin());
                 
 #ifdef __APPLE__
                 if(base.is_key_pressed(Codes::LSystem))
@@ -1583,18 +1587,10 @@ void BlobView::draw_boundary_selection(DrawStructure& base, Base* window, GUICac
                     auto mpos = coords.convert(HUDCoord{base.mouse_position()});
                     if(Bounds(p + Vec2(combine->origin().x == 0 ? 15 : -15,
                                        combine->origin().y == 0 ? 5 : -5)
-                              .mul(sca) - combine->size().mul(sca).mul(combine->origin()), combine->size().mul(sca)).contains(mpos))
+                              .mul(sca) - object_size.mul(combine->origin()), object_size).contains(mpos))
                     {
                         p = mpos;
-                        
-                        screen_pos = coords.convert(BowlCoord{p});
-                        float top = screen_pos.y < coords.screen_size().height * 0.5
-                            ? 0.f : 1.f;
-                        if(screen_pos.x < coords.screen_size().width * 0.5) {
-                            combine->set_origin(Vec2(0, top));
-                        } else {
-                            combine->set_origin(Vec2(1, top));
-                        }
+                        update_origin();
                     }
                 }
                 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -12,11 +12,9 @@
 {% set number = environ.get('GIT_DESCRIBE_NUMBER', '0') %}
 {% set hash = environ.get('GIT_DESCRIBE_HASH', '0') %}
 
-{% if git_tag != 'main' %}
 {% set version_prefix = '' %}
+{% if git_tag != 'main' and hash != git_tag_sanitized and not hash.startswith(git_tag_sanitized + '_') %}
 {% set hash = git_tag_sanitized + '_' + hash %}
-{% else %}
-{% set version_prefix = '' %}
 {% endif %}
 
 {% set version = ((latest_tag if latest_tag else '-failed') + version_prefix + version_postfix)[1:] %}


### PR DESCRIPTION
This PR contains two narrow fixes on the same release branch:

- Keep the boundary-selection popup clamp in the same coordinate space as its rendered menu anchor, so high zoom does not push the menu off-canvas.
- Avoid duplicate tag text in conda build strings for exact tag builds, while preserving sanitized ref prefixes for non-main branch builds. This keeps the replacement `v2.0.1` package names from looking like `v2.0.1_v2.0.1...` without dropping the branch-name disambiguation needed for unusual refs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boundary-selection overlay positioning and scaling across UI zoom levels, reducing visual jitter when snapping and moving selections.

* **Chores**
  * Refined build/versioning logic to better handle non-main branch/tag builds so package versions are generated more predictably.

* **Documentation**
  * Added repository-specific contributor and tooling guidance to help with conventions, GUI rules, testing, and build workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->